### PR TITLE
Added Playwright E2E test cases for timezone-app

### DIFF
--- a/timezone-app/e2e/example.spec.ts
+++ b/timezone-app/e2e/example.spec.ts
@@ -1,8 +1,100 @@
 import { test, expect } from '@playwright/test';
+import { TimezonePage } from './pages/timezone.page';
 
-test('has title', async ({ page }) => {
-  await page.goto('localhost:3000');
+test.describe('Timezone tests', () => {
 
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Time Keeper/);
+    let timezonePage: TimezonePage;
+
+    test.beforeEach(async ({ page }) => {
+        timezonePage = new TimezonePage(page);
+        await timezonePage.goto();
+    });
+
+
+    test('has title', async ({ page }) => {
+        // Expect a title "to contain" a substring.
+        await expect(page).toHaveTitle(/Time Keeper/);
+    });
+
+    test('should display the user\'s local timezone automatically', async ({ page }) => {
+        // Without adding any row, one row with local timezone should already exist
+        const localTimezoneRow = page.locator('tr:has-text("You")');
+        await expect(localTimezoneRow).toBeVisible();
+    });
+
+    test('should sort the table by the current time, earliest first', async ({ page }) => {
+        // Add multiple timezones
+        await timezonePage.addTimezone('Mountain HQ', 'America/Denver');
+        await timezonePage.addTimezone('Central HQ', 'America/Chicago');
+        await timezonePage.addTimezone('Eastern HQ', 'America/New_York');
+        await timezonePage.addTimezone('Pacific HQ', 'America/Los_Angeles');
+        await timezonePage.addTimezone('Honululu HQ', 'Pacific/Honolulu');
+
+        // Get innerText from all rows and save it under times array
+        const tableRows = page.locator('table tbody tr');
+        const times = await tableRows.allInnerTexts();
+
+        var todayDate = new Date().toLocaleDateString();
+        // Since time is the third cell in each row, hence splitting the cell data
+        // Saving the sorted timezones in sortedTimes array
+        const sortedTimes = times.slice().sort((a, b) => {
+            const timeA = a.split('\t')[2]; 
+            const timeB = b.split('\t')[2];
+            return Date.parse(todayDate + ' ' + timeA) - Date.parse(todayDate + ' ' + timeB);
+        });
+
+        // Expecting the results to be sorted
+        for (let i = 0; i < times.length; i++) {
+            expect(times[i]).toBe(sortedTimes[i]);
+        }
+    });
+
+    test('should allow the user to add a timezone', async ({ page }) => {
+        // Add new time zone and expect the newly added row to be visible
+        await timezonePage.addTimezone('Mountain HQ', 'America/Denver');
+        const newTimezoneRow = page.locator('text="Mountain HQ"');
+        await expect(newTimezoneRow).toBeVisible();
+    });
+
+    test('should not allow the deletion of the "You" record', async ({ page }) => {
+        // Delete of local(You) record should not be allowed
+        await page.goto('/');
+        const localTZRow = page.locator('tr:has-text("You")');
+        await expect(localTZRow.locator('button:text("Delete")')).toBeDisabled();
+    });
+
+    test('should not allow the user to add a timezone with no label', async ({ page }) => {
+        // Add new timezone without label and expect that it should not be saved
+        await timezonePage.addTimezone('', 'America/Denver');
+        await expect(page.locator('tr:has-text("America/Denver")')).toHaveCount(0);
+    });
+
+    test('should not allow the user to add a label with no timezone', async ({ page }) => {
+        // Add new label without timezone and expect that it should not be saved
+        await timezonePage.addTimezone('Tor HQ', '');
+        await expect(page.locator('tr:has-text("Tor HQ")')).toHaveCount(0);
+    });
+
+    test('should only delete one entry if multiple entries exist with same label name', async ({ page }) => {
+        // Add two timezones with same label name and then delete one row
+        // expect only one row to be deleted 
+        await timezonePage.addTimezone('Pacific HQ', 'America/Los_Angeles');
+        const newTimezoneRow = page.locator('tr:has-text("Pacific HQ")');
+        await expect(newTimezoneRow).toBeVisible();
+        await timezonePage.addTimezone('Pacific HQ', 'Pacific/Honolulu');
+        const newUpdatedTimezoneRow = page.locator('tr:has-text("Pacific HQ")');
+        await expect(newUpdatedTimezoneRow).toHaveCount(2);
+        await timezonePage.deleteTimezone('Pacific HQ');
+        await expect(page.locator('tr:has-text("Pacific HQ")')).toHaveCount(1);
+    });
+
+    test('User should be able to delete row which doesn\'t have local time', async ({ page }) => {
+        // add new timezone 
+        await timezonePage.addTimezone('Pacific HQ', 'America/Los_Angeles');
+        const newTimezoneRow = page.locator('tr:has-text("Pacific HQ")');
+        await expect(newTimezoneRow).toBeVisible();
+        // user should be able to delete non local(you) record
+        await timezonePage.deleteTimezone('Pacific HQ');
+        await expect(page.locator('tr:has-text("Pacific HQ")')).toHaveCount(0);
+    });
 });

--- a/timezone-app/e2e/pages/timezone.page.ts
+++ b/timezone-app/e2e/pages/timezone.page.ts
@@ -1,0 +1,43 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class TimezonePage {
+    page: Page;
+    localTimezoneRecord: Locator;
+    addTimezoneNameInput: Locator;
+    addTimezoneInput: Locator;
+    addTimezoneButton: Locator;
+    timezoneTableRows: Locator;
+    deleteButtons: Locator;
+    saveButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.localTimezoneRecord = page.locator('text="You"');
+        this.addTimezoneNameInput = page.locator('input[name="label"]');
+        this.addTimezoneInput = page.locator('select[id="timezone"]');
+        this.addTimezoneButton = page.locator('button:text("Add timezone")');
+        this.timezoneTableRows = page.locator('tbody tr');
+        this.deleteButtons = page.locator('button:text("Delete")');
+        this.saveButton = page.locator('button:text("Save")');
+    }
+
+    async goto() {
+        await this.page.goto('/');
+    }
+
+    async addTimezone(name: string, timezone: string) {
+        // add new TimeZone by selecting TimeZone and adding label name
+        await this.addTimezoneButton.click();
+        await this.addTimezoneNameInput.fill(name);
+        await this.addTimezoneInput.selectOption(timezone);
+        await this.saveButton.click();
+    }
+
+    async deleteTimezone(name: string) {
+        // delete Timezone using label and if multiple rows exist with same labels, delete first row
+        const localTZRow = this.page.locator(`tr:has-text("${name}")`);
+        await localTZRow.locator('button:text("Delete")').nth(0).click();
+
+    }
+}
+

--- a/timezone-app/package.json
+++ b/timezone-app/package.json
@@ -16,7 +16,7 @@
     "autoprefixer": "10.4.15",
     "eslint": "8.49.0",
     "eslint-config-next": "13.4.19",
-    "next": "13.4.19",
+    "next": "15.1.6",
     "postcss": "8.4.29",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/timezone-app/playwright.config.ts
+++ b/timezone-app/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'http://localhost:3000/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",


### PR DESCRIPTION
#### Changes included
Updated next.js version in package.json to remove Hydration errors in timezone app

Tests are written based on PageObjectModel
File **e2e/pages/timezone.page.ts** contains common fixture methods of adding and deleting timezones
File **e2e/example.spec.ts** contains E2E tests for timezone-app based upon requirements